### PR TITLE
build: add workspace flag to pnpm install backend npm packages

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -7,7 +7,7 @@ applications:
           commands:
             - npm install -g pnpm
             - pnpm --version
-            - pnpm install --frozen-lockfile
+            - pnpm -w install --frozen-lockfile
         build:
           commands:
             - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
@@ -18,7 +18,7 @@ applications:
           commands:
             - npm install -g pnpm
             - pnpm --version
-            - pnpm install --frozen-lockfile
+            - pnpm -w install --frozen-lockfile
         build:
           commands:
             - pnpm run build

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "amplify"


### PR DESCRIPTION
…space packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to use workspace-aware package installation for both backend and frontend, improving consistency across projects.
  * Expanded the package workspace to include the Amplify project, ensuring dependencies are installed and managed uniformly.
  * Overall improves reliability and predictability of installs during CI/CD and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->