### PR TITLE
clear tooltip editor when navigating between steps

### DIFF
--- a/apps/webapp/src/pages/DemoEditorPage.tsx
+++ b/apps/webapp/src/pages/DemoEditorPage.tsx
@@ -454,6 +454,13 @@ export function DemoEditorPage() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // Clear tooltip editor when navigating to a different step
+  useEffect(() => {
+    setEditingTooltip(null);
+    setTooltipTitle("");
+    setTooltipDescription("");
+  }, [selectedStepIndex]);
+
   // Recompute positions on container resize (image area changes with responsive layout)
   useEffect(() => {
     const el = imageRef.current;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where tooltip edits would incorrectly persist when navigating between steps in the demo editor. Tooltip modifications are now properly reset when switching to a new step, preventing unintended carryover of edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->